### PR TITLE
cmptest: Move go test comparison into cmptest

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1,26 +1,30 @@
-package faket
+package faket_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/prashantv/faket/internal/cmptest"
+)
 
 // These integration-style tests are used to compare the real output of running
 // a test to the result of `RunTest`.
 
 func TestCmp_Success(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("log1")
 		t.Log("log2")
 	})
 }
 
 func TestCmp_LogFormatting(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("a", 1, "b", 2, "c", "d")
 		t.Logf("a: %v b: %v", 1, 2)
 	})
 }
 
 func TestCmp_Skip(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("pre-skip")
 		t.Skip("skip")
 		t.Log("post-skip")
@@ -28,7 +32,7 @@ func TestCmp_Skip(t *testing.T) {
 }
 
 func TestCmp_Failure(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("pre-fail log")
 		t.Error("error log")
 		t.Log("post-fail log")
@@ -44,21 +48,21 @@ func TestCmp_Failure(t *testing.T) {
 // }
 
 func TestCmp_FailThenSkipCmp(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Error("error")
 		t.Skip("skipped")
 	})
 }
 
 func TestCmp_SkipThenFail(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Skip("skip")
 		t.Error("skipped error")
 	})
 }
 
 func TestCmp_Fatal(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("pre-fatal")
 		t.Fatal("fatal")
 		t.Log("post-fatal")
@@ -66,7 +70,7 @@ func TestCmp_Fatal(t *testing.T) {
 }
 
 func TestCmp_Cleanup(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("log 1")
 		t.Cleanup(func() {
 			t.Log("log in cleanup")
@@ -76,7 +80,7 @@ func TestCmp_Cleanup(t *testing.T) {
 }
 
 func TestCmp_CleanupError(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("log 1")
 		t.Cleanup(func() {
 			t.Error("error in cleanup")
@@ -86,7 +90,7 @@ func TestCmp_CleanupError(t *testing.T) {
 }
 
 func TestCmp_CleanupSkip(t *testing.T) {
-	compareTest(t, func(t testing.TB) {
+	cmptest.Compare(t, func(t testing.TB) {
 		t.Log("log 1")
 		t.Cleanup(func() {
 			t.Log("cleanup 1")

--- a/internal/cmptest/cmptest.go
+++ b/internal/cmptest/cmptest.go
@@ -1,4 +1,5 @@
-package faket
+// Package cmptest is used to compare faket against go test.
+package cmptest
 
 import (
 	"bytes"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prashantv/faket"
 	"github.com/prashantv/faket/internal/want"
 )
 
@@ -46,7 +48,9 @@ func mustReadTestEvents(file string) map[string][]TestEvent {
 	return events
 }
 
-func compareTest(t *testing.T, f func(testing.TB)) {
+// Compare compares the result of running the given test function
+// using `faket.RunTest` against `go test`.
+func Compare(t *testing.T, f func(testing.TB)) {
 	// Verify the name, since the Makefile uses this to only run Cmp tests when generating the test data.
 	if !strings.HasPrefix(t.Name(), "TestCmp_") {
 		t.Fatalf("test %v is a Cmp test, and should be named TestCmp_*", t.Name())
@@ -57,7 +61,7 @@ func compareTest(t *testing.T, f func(testing.TB)) {
 		return
 	}
 
-	res := RunTest(f)
+	res := faket.RunTest(f)
 
 	var wantOutput []string
 	realTestEvents := testEvents[t.Name()]
@@ -90,5 +94,5 @@ func compareTest(t *testing.T, f func(testing.TB)) {
 	}
 
 	want.Equal(t, "result event", resultEvent, true)
-	want.DeepEqual(t, "log output", res.testingLogOutput(), wantOutput)
+	want.DeepEqual(t, "log output", res.LogsWithCaller(), wantOutput)
 }

--- a/test_result.go
+++ b/test_result.go
@@ -47,7 +47,9 @@ func (r TestResult) Logs() string {
 	return strings.Join(r.LogsList(), "\n")
 }
 
-func (r TestResult) testingLogOutput() []string {
+// LogsWithCaller returns the log output of the test with caller information
+// similar to the output of `go test`.
+func (r TestResult) LogsWithCaller() []string {
 	logs := make([]string, 0, len(r.res.Logs))
 	for _, l := range r.res.Logs {
 		line := fmt.Sprintf("%v: %v", getFileLine(l.callers), l.entry)

--- a/testdata/cmp_test_results.json
+++ b/testdata/cmp_test_results.json
@@ -1,68 +1,68 @@
 {"Time":"2022-06-11T00:00:00.0Z","Action":"start","Package":"github.com/prashantv/faket"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_Success"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Output":"=== RUN   TestCmp_Success\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Output":"    integration_test.go:10: log1\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Output":"    integration_test.go:11: log2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Output":"    integration_test.go:14: log1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Output":"    integration_test.go:15: log2\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Output":"--- PASS: TestCmp_Success (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"pass","Package":"github.com/prashantv/faket","Test":"TestCmp_Success","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Output":"=== RUN   TestCmp_LogFormatting\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Output":"    integration_test.go:17: a 1 b 2 c d\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Output":"    integration_test.go:18: a: 1 b: 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Output":"    integration_test.go:21: a 1 b 2 c d\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Output":"    integration_test.go:22: a: 1 b: 2\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Output":"--- PASS: TestCmp_LogFormatting (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"pass","Package":"github.com/prashantv/faket","Test":"TestCmp_LogFormatting","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Output":"=== RUN   TestCmp_Skip\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Output":"    integration_test.go:24: pre-skip\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Output":"    integration_test.go:25: skip\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Output":"    integration_test.go:28: pre-skip\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Output":"    integration_test.go:29: skip\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Output":"--- SKIP: TestCmp_Skip (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"skip","Package":"github.com/prashantv/faket","Test":"TestCmp_Skip","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"=== RUN   TestCmp_Failure\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"    integration_test.go:32: pre-fail log\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"    integration_test.go:33: error log\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"    integration_test.go:34: post-fail log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"    integration_test.go:36: pre-fail log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"    integration_test.go:37: error log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"    integration_test.go:38: post-fail log\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Output":"--- FAIL: TestCmp_Failure (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket","Test":"TestCmp_Failure","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Output":"=== RUN   TestCmp_FailThenSkipCmp\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Output":"    integration_test.go:48: error\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Output":"    integration_test.go:49: skipped\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Output":"    integration_test.go:52: error\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Output":"    integration_test.go:53: skipped\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Output":"--- FAIL: TestCmp_FailThenSkipCmp (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket","Test":"TestCmp_FailThenSkipCmp","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_SkipThenFail"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_SkipThenFail","Output":"=== RUN   TestCmp_SkipThenFail\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_SkipThenFail","Output":"    integration_test.go:55: skip\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_SkipThenFail","Output":"    integration_test.go:59: skip\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_SkipThenFail","Output":"--- SKIP: TestCmp_SkipThenFail (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"skip","Package":"github.com/prashantv/faket","Test":"TestCmp_SkipThenFail","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Output":"=== RUN   TestCmp_Fatal\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Output":"    integration_test.go:62: pre-fatal\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Output":"    integration_test.go:63: fatal\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Output":"    integration_test.go:66: pre-fatal\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Output":"    integration_test.go:67: fatal\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Output":"--- FAIL: TestCmp_Fatal (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket","Test":"TestCmp_Fatal","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"=== RUN   TestCmp_Cleanup\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"    integration_test.go:70: log 1\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"    integration_test.go:74: log 2\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"    integration_test.go:72: log in cleanup\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"    integration_test.go:74: log 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"    integration_test.go:78: log 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"    integration_test.go:76: log in cleanup\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Output":"--- PASS: TestCmp_Cleanup (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"pass","Package":"github.com/prashantv/faket","Test":"TestCmp_Cleanup","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"=== RUN   TestCmp_CleanupError\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"    integration_test.go:80: log 1\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"    integration_test.go:84: log 2\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"    integration_test.go:82: error in cleanup\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"    integration_test.go:84: log 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"    integration_test.go:88: log 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"    integration_test.go:86: error in cleanup\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Output":"--- FAIL: TestCmp_CleanupError (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupError","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"=== RUN   TestCmp_CleanupSkip\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:90: log 1\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:102: log 2\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:100: cleanup 3\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:95: cleanup 2\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:96: skip in cleanup\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:92: cleanup 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:94: log 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:106: log 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:104: cleanup 3\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:99: cleanup 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:100: skip in cleanup\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:96: cleanup 1\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"--- SKIP: TestCmp_CleanupSkip (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"skip","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"FAIL\n"}


### PR DESCRIPTION
This is a prefactor for allowing integration tests in other packages, which is required for panic testing.

As part of this, we need to export the caller information in logs.