### PR TITLE
Generate cmp_test_results in multiple directories

### DIFF
--- a/scripts/gencmp.sh
+++ b/scripts/gencmp.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# arg1 = relative directory (or go package) to test.
+cd "$1"
+
+RUN_ACTUAL_TEST=1 go test -v -trimpath -run TestCmp_ -json |
+	# Replace time & timestamps
+	perl -pe 's/"Time":".*?"/"Time":"2022-06-11T00:00:00.0Z"/' |
+	perl -pe 's/[0-9]+\.[0-9]+s/0.01s/g' |
+	perl -pe 's/"Elapsed":[0-9]+\.[0-9]+/"Elapsed":1.00/' |
+
+	# dummy cat for consistently terminating above commands with |
+	cat


### PR DESCRIPTION
Generate cmp_test_results in any directory, and to simplify actions with macros,
move go test + replacement logic into a separate shell script.

The testdata files are only regenerated if `*_test.go` files in the directory change
(or the cmptest go files change). To force a rerun, add a `force-update-testdata`
target, which is an alias for `make -B update-testdata`.