### PR TITLE
Add TestResult.Panicked and test panic detection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,4 +35,5 @@ jobs:
       run: go test -v ./...
 
     - name: Verify golden files
+      if: matrix.go-version == '1.23.x'
       run: make diff-testdata

--- a/internal/cmptest/cmptest.go
+++ b/internal/cmptest/cmptest.go
@@ -58,6 +58,16 @@ func mustReadTestEvents(file string) map[string][]TestEvent {
 // Compare compares the result of running the given test function
 // using `faket.RunTest` against `go test`.
 func Compare(t *testing.T, f func(testing.TB)) {
+	CompareOpts(t, Opts{}, f)
+}
+
+// Opts are options for comparing faket to a real test run.
+type Opts struct {
+	WantPanic bool
+}
+
+// CompareOpts is the same as Compare, but supports options for customizing comparisons.
+func CompareOpts(t *testing.T, opts Opts, f func(t testing.TB)) {
 	// Verify the name, since the Makefile uses this to only run Cmp tests when generating the test data.
 	if !strings.HasPrefix(t.Name(), "TestCmp_") {
 		t.Fatalf("test %v is a Cmp test, and should be named TestCmp_*", t.Name())
@@ -102,4 +112,5 @@ func Compare(t *testing.T, f func(testing.TB)) {
 
 	want.Equal(t, "result event", resultEvent, true)
 	want.DeepEqual(t, "log output", res.LogsWithCaller(), wantOutput)
+	want.Equal(t, "panicked", res.Panicked(), opts.WantPanic)
 }

--- a/internal/panictests/p1/panic_1_test.go
+++ b/internal/panictests/p1/panic_1_test.go
@@ -1,0 +1,17 @@
+package p1
+
+import (
+	"testing"
+
+	"github.com/prashantv/faket/internal/cmptest"
+)
+
+func TestCmp_Panic(t *testing.T) {
+	opts := cmptest.Opts{WantPanic: true}
+	cmptest.CompareOpts(t, opts, func(t testing.TB) {
+		defer t.Log("defer log")
+		t.Log("normal log")
+
+		panic("fatal")
+	})
+}

--- a/internal/panictests/p1/testdata/cmp_test_results.json
+++ b/internal/panictests/p1/testdata/cmp_test_results.json
@@ -1,0 +1,30 @@
+{"Time":"2022-06-11T00:00:00.0Z","Action":"start","Package":"github.com/prashantv/faket/internal/panictests/p1"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"=== RUN   TestCmp_Panic\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"    panic_1_test.go:13: normal log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"    panic_1_test.go:15: defer log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"--- FAIL: TestCmp_Panic (0.01s)\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"panic: fatal [recovered]\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\tpanic: fatal\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"goroutine 1 [running]:\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"testing.tRunner.func1.2({0x0000, 0x0000})\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1632 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"testing.tRunner.func1()\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1635 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"panic({0x0000?, 0x0000?})\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\truntime/panic.go:785 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"github.com/prashantv/faket/internal/panictests/p1.TestCmp_Panic.func1({0x0000, 0x0000})\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\tgithub.com/prashantv/faket/internal/panictests/p1/panic_1_test.go:15 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"github.com/prashantv/faket/internal/cmptest.CompareOpts(0x0000, {0x0000?}, 0x0000?)\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\tgithub.com/prashantv/faket/internal/cmptest/cmptest.go:77 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"github.com/prashantv/faket/internal/panictests/p1.TestCmp_Panic(0x0000?)\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\tgithub.com/prashantv/faket/internal/panictests/p1/panic_1_test.go:11 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"testing.tRunner(0x0000, 0x0000)\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1690 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"created by testing.(*T).Run in goroutine 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1743 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"exit status 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Elapsed":0}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Output":"FAIL\tgithub.com/prashantv/faket/internal/panictests/p1\t0.01s\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket/internal/panictests/p1","Elapsed":1.00}

--- a/internal/panictests/p1/testdata/cmp_test_results.json
+++ b/internal/panictests/p1/testdata/cmp_test_results.json
@@ -9,11 +9,11 @@
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"goroutine 1 [running]:\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"testing.tRunner.func1.2({0x0000, 0x0000})\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1632 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"testing.tRunner.func1()\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1635 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"panic({0x0000?, 0x0000?})\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\truntime/panic.go:785 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\truntime/panic.go:1 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"github.com/prashantv/faket/internal/panictests/p1.TestCmp_Panic.func1({0x0000, 0x0000})\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\tgithub.com/prashantv/faket/internal/panictests/p1/panic_1_test.go:15 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"github.com/prashantv/faket/internal/cmptest.CompareOpts(0x0000, {0x0000?}, 0x0000?)\n"}
@@ -21,9 +21,9 @@
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"github.com/prashantv/faket/internal/panictests/p1.TestCmp_Panic(0x0000?)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\tgithub.com/prashantv/faket/internal/panictests/p1/panic_1_test.go:11 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"testing.tRunner(0x0000, 0x0000)\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1690 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"created by testing.(*T).Run in goroutine 1\n"}
-{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1743 +0x0000\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"\ttesting/testing.go:1 +0x0000\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Output":"exit status 2\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"fail","Package":"github.com/prashantv/faket/internal/panictests/p1","Test":"TestCmp_Panic","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket/internal/panictests/p1","Output":"FAIL\tgithub.com/prashantv/faket/internal/panictests/p1\t0.01s\n"}

--- a/scripts/gencmp.sh
+++ b/scripts/gencmp.sh
@@ -13,5 +13,8 @@ RUN_ACTUAL_TEST=1 go test -v -trimpath -run TestCmp_ -json |
 	perl -pe 's/0x[0-9a-fA-F]+/0x0000/g' |
 	perl -pe 's/goroutine [0-9]+/goroutine 1/g' |
 
+	# Replace line numbers in stdlib files (matches */*.go)
+	perl -pe 's/(\\t[a-z]+\/[a-z]+.go):[0-9]+/\1:1/g' |
+
 	# dummy cat for consistently terminating above commands with |
 	cat

--- a/scripts/gencmp.sh
+++ b/scripts/gencmp.sh
@@ -9,5 +9,9 @@ RUN_ACTUAL_TEST=1 go test -v -trimpath -run TestCmp_ -json |
 	perl -pe 's/[0-9]+\.[0-9]+s/0.01s/g' |
 	perl -pe 's/"Elapsed":[0-9]+\.[0-9]+/"Elapsed":1.00/' |
 
+	# Replace pointers & goroutine IDs 
+	perl -pe 's/0x[0-9a-fA-F]+/0x0000/g' |
+	perl -pe 's/goroutine [0-9]+/goroutine 1/g' |
+
 	# dummy cat for consistently terminating above commands with |
 	cat


### PR DESCRIPTION
Fix panic detection, and track panicked values + callers (though they're not exposed yet).

Note: Panic handling varies between faket and go test as
go test stops running *all* tests within the package on panic,
while faket only stops the specific test.

Panics should be avoided in test helpers,
but if there is a panic scenario that needs to be tested,
returning a result seems more useful than exiting.