### PR TITLE
exp/retryt: Retry a `func(testing.TB)` till it passes

### DIFF
--- a/exp/retryt/opts.go
+++ b/exp/retryt/opts.go
@@ -1,0 +1,48 @@
+package retryt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prashantv/faket"
+)
+
+// Opts are options to customize retryt.
+type Opts struct {
+	// Attempts is the maximum number of times the test function will be run.
+	// If <= 0, defaults to 10.
+	Attempts int
+
+	// Retry is run after a failed run that will be retried.
+	// By default, Retry logs the attempt number, and sleeps for
+	// <attempt> milliseconds as a backoff.
+	Retry func(t testing.TB, attempt int, tr faket.TestResult)
+
+	// Passed is run after a successful run of the function passed to [Test].
+	Passed func(t testing.TB, attempt int, tr faket.TestResult)
+}
+
+func (o *Opts) setDefaults() {
+	if o.Attempts <= 0 {
+		o.Attempts = 10
+	}
+	if o.Retry == nil {
+		o.Retry = noop
+	}
+	if o.Passed == nil {
+		o.Passed = noop
+	}
+}
+
+// RetryBackoff logs `attempt`, and sleeps for `attempt` milliseconds.
+//
+// It's intended to be used as [Opts].Retry to log and backoff on failure.
+func RetryBackoff(t testing.TB, attempt int, tr faket.TestResult) {
+	t.Helper()
+
+	sleepFor := time.Duration(attempt) * time.Millisecond
+	t.Logf("retryt attempt %d failed, retrying in %v", attempt, sleepFor)
+	time.Sleep(sleepFor)
+}
+
+func noop(testing.TB, int, faket.TestResult) {}

--- a/exp/retryt/retryt.go
+++ b/exp/retryt/retryt.go
@@ -1,0 +1,49 @@
+// Package retryt can retry test assertions
+// that may need multiple attempts to succeed.
+//
+// This is useful for tests that are waiting for some background work.
+package retryt
+
+import (
+	"testing"
+
+	"github.com/prashantv/faket"
+)
+
+// N runs `testFn“ upto N times, with [RetryBackoff] for retries.
+// See [Run] for more details.
+func N(t testing.TB, n int, testFn func(testing.TB)) {
+	t.Helper()
+
+	Opts{
+		Attempts: n,
+		Retry:    RetryBackoff,
+	}.Run(t, testFn)
+}
+
+// Run tries `testFn` till it succeeds, or fails too many times.
+// `opts` is used to customize retry behaviour.
+//
+// A last attempt is run against `t` so logs and failures are reported.
+func Run(t testing.TB, opts Opts, testFn func(testing.TB)) {
+	t.Helper()
+
+	opts.setDefaults()
+	for attempt := 1; attempt < opts.Attempts; attempt++ {
+		tr := faket.RunTest(testFn)
+
+		if !tr.Failed() {
+			opts.Passed(t, attempt, tr)
+			break
+		} else {
+			opts.Retry(t, attempt, tr)
+		}
+	}
+
+	testFn(t)
+}
+
+// Run is an alias for [Run].
+func (os Opts) Run(t testing.TB, testFn func(testing.TB)) {
+	Run(t, os, testFn)
+}

--- a/exp/retryt/retryt_test.go
+++ b/exp/retryt/retryt_test.go
@@ -1,0 +1,125 @@
+package retryt_test
+
+import (
+	"testing"
+
+	"github.com/prashantv/faket"
+	"github.com/prashantv/faket/exp/retryt"
+	"github.com/prashantv/faket/internal/want"
+)
+
+func TestN(t *testing.T) {
+	const n = 5
+	tests := []struct {
+		name            string
+		innerFn         func(t testing.TB, count int)
+		wantSkipped     bool
+		wantFailed      bool
+		wantCount       int
+		containsLogs    []string
+		notContainsLogs []string
+	}{
+		{
+			name:      "pass noop",
+			innerFn:   func(testing.TB, int) {},
+			wantCount: 2, /* faket run + real testing.TB run */
+		},
+		{
+			name: "pass 2nd attempt",
+			innerFn: func(t testing.TB, count int) {
+				want.Equal(t, "count", count, 2)
+			},
+			wantFailed: true,  // needs to pass consistently, but fails on final attempt.
+			wantCount:  2 + 1, // 2 runs to pass on faket + final attempt,
+			containsLogs: []string{
+				"retryt attempt 1 failed",
+				"count: expected equal",
+			},
+			notContainsLogs: []string{
+				"retryt attempt 2 failed", // 2nd attempt succeeds
+				"retryt attempt 3 failed", // No retries after 2nd attempt succeeds
+			},
+		},
+		{
+			name: "pass last attempt",
+			innerFn: func(t testing.TB, count int) {
+				t.Log("count =", count)
+				want.Equal(t, "count", count, n)
+			},
+			wantCount: n,
+			containsLogs: []string{
+				"retryt attempt 1 failed, retrying in 1ms",
+				"retryt attempt 4 failed, retrying in 4ms",
+				"count = 5",
+			},
+			notContainsLogs: []string{
+				"retry attempt 5 failed", // last attempt passes
+			},
+		},
+		{
+			name: "skip",
+			innerFn: func(t testing.TB, count int) {
+				t.Skip("skip in testFn")
+			},
+			wantSkipped: true,
+			wantCount:   2, /* faket run + real testing.TB run */
+			containsLogs: []string{
+				"skip in testFn",
+			},
+			notContainsLogs: []string{
+				"retry attempt 1 failed", // no retries on skip
+			},
+		},
+		{
+			name: "fail",
+			innerFn: func(t testing.TB, count int) {
+				want.Equal(t, "count", 0, count)
+			},
+			wantFailed: true,
+			wantCount:  n,
+			containsLogs: []string{
+				"retryt attempt 1 failed, retrying in 1ms",
+				"retryt attempt 4 failed, retrying in 4ms",
+				"got:  0\nwant: 5",
+			},
+			notContainsLogs: []string{
+				"retryt attempt 5 failed", // last attempt is not logged
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var count int
+			tr := faket.RunTest(func(t testing.TB) {
+				retryt.N(t, n, func(t testing.TB) {
+					count++
+					tt.innerFn(t, count)
+				})
+			})
+			want.Equal(t, "Skipped", tr.Skipped(), tt.wantSkipped)
+			want.Equal(t, "Failed", tr.Failed(), tt.wantFailed)
+			for _, log := range tt.containsLogs {
+				want.Contains(t, "logs", tr.Logs(), log)
+			}
+			for _, log := range tt.notContainsLogs {
+				want.NotContains(t, "logs", tr.Logs(), log)
+			}
+			want.Equal(t, "run count", count, tt.wantCount)
+		})
+	}
+}
+
+func TestRun_Defaults(t *testing.T) {
+	var count int
+	tr := faket.RunTest(func(t testing.TB) {
+		retryt.Opts{}.Run(t, func(t testing.TB) {
+			count++
+			t.Fatal("fail")
+		})
+	})
+	want.Equal(t, "Failed", tr.Failed(), true)
+	want.Equal(t, "run count", count, 10)
+	want.Contains(t, "logs", tr.Logs(), "fail")
+	want.NotContains(t, "logs", tr.Logs(), "retryt") // no logs by default
+}

--- a/internal/want/want.go
+++ b/internal/want/want.go
@@ -2,6 +2,7 @@ package want
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -25,6 +26,27 @@ func Equal[T comparable](t testing.TB, msg string, got, want T) {
 	}
 
 	t.Fatalf("%s: expected equal\ngot:  %v\nwant: %v", msg, got, want)
+}
+
+// Contains asserts that the given substring is contained.
+func Contains(t testing.TB, msg string, got, contains string) {
+	t.Helper()
+
+	if strings.Contains(got, contains) {
+		return
+	}
+
+	t.Fatalf("%s: expected contains\ngot: %s\nwant contains: %s", msg, got, contains)
+}
+
+func NotContains(t testing.TB, msg string, got, notContains string) {
+	t.Helper()
+
+	if !strings.Contains(got, notContains) {
+		return
+	}
+
+	t.Fatalf("%s: expected not contains\ngot: %s\nshould not contain: %s", msg, got, notContains)
 }
 
 // DeepEqual assers that the given got/want are equal using reflect.DeepEqual.

--- a/internal/want/want_test.go
+++ b/internal/want/want_test.go
@@ -106,3 +106,103 @@ func TestDeepEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      string
+		contains string
+		wantFail string
+	}{
+		{
+			name:     "empty contains empty",
+			got:      "",
+			contains: "",
+		},
+		{
+			name:     "non-empty contains empty",
+			got:      "str",
+			contains: "",
+		},
+		{
+			name:     "empty doesn't contain a",
+			got:      "",
+			contains: "a",
+			wantFail: "log contains: expected contains",
+		},
+		{
+			name:     "str contains str",
+			got:      "str",
+			contains: "str",
+		},
+		{
+			name:     "str contains s",
+			got:      "str",
+			contains: "s",
+		},
+		{
+			name:     "str contains r",
+			got:      "str",
+			contains: "r",
+		},
+		{
+			name:     "str doesn't contain a",
+			got:      "str",
+			contains: "a",
+			wantFail: "log contains: expected contains",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := faket.RunTest(func(t testing.TB) {
+				want.Contains(t, "log contains", tt.got, tt.contains)
+			})
+			if tt.wantFail == "" {
+				tr.MustPass(t)
+			} else {
+				tr.MustFail(t, tt.wantFail)
+			}
+		})
+	}
+}
+
+func TestNotContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      string
+		contains string
+		wantFail string
+	}{
+		{
+			name:     "empty not contains empty",
+			got:      "",
+			contains: "",
+			wantFail: "logs should not contain: expected not contains",
+		},
+		{
+			name:     "str not contains a",
+			got:      "str",
+			contains: "a",
+		},
+		{
+			name:     "str not contains s",
+			got:      "str",
+			contains: "s",
+			wantFail: "logs should not contain: expected not contains",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := faket.RunTest(func(t testing.TB) {
+				want.NotContains(t, "logs should not contain", tt.got, tt.contains)
+			})
+			if tt.wantFail == "" {
+				tr.MustPass(t)
+			} else {
+				tr.MustFail(t, tt.wantFail)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add an experimental package that uses faket to implement a helper to retry test assertions till they succeed.

This is intended for assertions against asynchronous work which would be flaky without a wait. By using retryt, tests can avoid custom code that waits for a condition independent of the test assertions.