### PR TITLE
Implement `t.Helper()` to skip helper frames

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,11 +5,6 @@
 * Support for Nested `t.Cleanup` function calls
   * With support for `t.Skip` inside the nested cleanup calls.
 
-## Tests
-
-* Implement `t.Helper` so file:line tracked matches real tests.
-  This only has test impact unless caller information for logs is exported.
-
 
 ## Cosmetic
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -107,3 +107,33 @@ func TestCmp_CleanupSkip(t *testing.T) {
 		t.Log("log 2")
 	})
 }
+
+func TestCmp_Helper(t *testing.T) {
+	cmptest.Compare(t, func(t testing.TB) {
+		t.Log("call log directly")
+		log(t)
+
+		t.Log("log in helper")
+		logHelper(t, 1, func() {})
+		logHelper(t, 3, func() {})
+
+		t.Log("log helper then log")
+		logHelper(t, 3, func() { log(t) })
+	})
+}
+
+func logHelper(t testing.TB, n int, last func()) {
+	t.Helper()
+
+	t.Log("logHelper", n)
+
+	if n == 0 {
+		last()
+		return
+	}
+	logHelper(t, n-1, last)
+}
+
+func log(t testing.TB) {
+	t.Log("log")
+}

--- a/test_result.go
+++ b/test_result.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -65,11 +66,26 @@ func (r TestResult) Logs() string {
 func (r TestResult) LogsWithCaller() []string {
 	logs := make([]string, 0, len(r.res.Logs))
 	for _, l := range r.res.Logs {
-		ci := getCallerInfo(l.callers)
+		ci := getCallerInfo(l.callers, r.Helpers())
 		line := fmt.Sprintf("%s:%d: %v", filepath.Base(ci.callerFile), ci.callerLine, l.entry)
 		logs = append(logs, line)
 	}
 	return logs
+}
+
+// Helpers returns a list of functions that have called [testing.TB].Helper.
+// The returned list is sorted by the full package+function.
+func (r TestResult) Helpers() []string {
+	funcs := make([]string, 0, len(r.res.helpers))
+	for pc := range r.res.helpers {
+		frames := runtime.CallersFrames([]uintptr{pc})
+		f, _ := frames.Next()
+		if f != (runtime.Frame{}) {
+			funcs = append(funcs, f.Function)
+		}
+	}
+	sort.Strings(funcs)
+	return funcs
 }
 
 type callerInfo struct {
@@ -79,7 +95,16 @@ type callerInfo struct {
 	callerLine int
 }
 
-func getCallerInfo(callers []uintptr) callerInfo {
+func getCallerInfo(callers []uintptr, skipFuncs []string) callerInfo {
+	skipSet := make(map[string]struct{})
+	for _, f := range skipFuncs {
+		skipSet[f] = struct{}{}
+	}
+
+	// When a defer is triggered by a panic, it's added to the trace
+	// but panic is not shown as a log caller.
+	skipSet["runtime.gopanic"] = struct{}{}
+
 	frames := runtime.CallersFrames(callers)
 
 	f, _ := frames.Next()
@@ -94,15 +119,12 @@ func getCallerInfo(callers []uintptr) callerInfo {
 
 	skip := true
 	for skip {
-		// TODO: Skip t.Helper() frames.
 		f, _ = frames.Next()
 		if f == (runtime.Frame{}) {
 			return ci
 		}
 
-		// When a defer is triggered by a panic, it's added to the trace
-		// but panic is not shown as a log caller.
-		skip = f.Function == "runtime.gopanic"
+		_, skip = skipSet[f.Function]
 	}
 
 	ci.callerFile = f.File

--- a/testdata/cmp_test_results.json
+++ b/testdata/cmp_test_results.json
@@ -65,6 +65,25 @@
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"    integration_test.go:97: cleanup 1\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Output":"--- SKIP: TestCmp_CleanupSkip (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"skip","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupSkip","Elapsed":0}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"=== RUN   TestCmp_Helper\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:113: call log directly\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:138: log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:116: log in helper\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:117: logHelper 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:117: logHelper 0\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:118: logHelper 3\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:118: logHelper 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:118: logHelper 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:118: logHelper 0\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:120: log helper then log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:121: logHelper 3\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:121: logHelper 2\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:121: logHelper 1\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:121: logHelper 0\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"    integration_test.go:138: log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Output":"--- PASS: TestCmp_Helper (0.01s)\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"pass","Package":"github.com/prashantv/faket","Test":"TestCmp_Helper","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"FAIL\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"exit status 1\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"FAIL\tgithub.com/prashantv/faket\t0.01s\n"}


### PR DESCRIPTION
Store the caller PC when `Helper` is called, and use this to generate a list of functions to skip.

The implementation aligns with how `testing.TB` skips helpers based on function rather than PC directly, likely to avoid issues with inlining, which can result in shared PC values for different functions.

Expose the list of helper functions via `TestResult.Helpers()` as it's required internally, and may be useful to verify that a helper correctly marks itself as a helper.