### PR TITLE
Move GO_NOT_LATEST set into .mise.oldstable.toml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         mise-env: ['oldstable', 'stable']
     env:
-      GO_NOT_LATEST: ${{ matrix.mise-env != 'stable' }}
       MISE_ENV: ${{ matrix.mise-env }}
 
     steps:

--- a/.mise.oldstable.toml
+++ b/.mise.oldstable.toml
@@ -1,2 +1,5 @@
 [tools]
 go = "1.22"
+
+[env]
+GO_NOT_LATEST = true


### PR DESCRIPTION
This allows for simpler testing of oldstable locally,
```
MISE_ENV=oldstable go test -v -run Nested
...
=== RUN   TestCmp_NestedCleanup/always_nest_with_skips
  integration_test.go:190: can only run with latest go
=== RUN   TestCmp_NestedCleanup/mix_nesting_and_skips
  integration_test.go:190: can only run with latest go
```

No need to set the GO_NOT_LATEST environment manually when using go 1.22 locally