### PR TITLE
Fix log callers when the cleanup uses `t.Helper()`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,5 @@
 
 ## Caller information
 
- * Check how caller information is reported when `t.Helper` and `t.Cleanup` are mixed.
  * Provide ability to get structured information for logs which include caller, function, etc.
    * Clean up the API around gettling logs (testing log output format, list, string, etc).

--- a/integration_test.go
+++ b/integration_test.go
@@ -217,3 +217,18 @@ func TestCmp_NestedCleanup(t *testing.T) {
 		})
 	}
 }
+
+func TestCmp_CleanupHelper(t *testing.T) {
+	cmptest.Compare(t, func(t testing.TB) {
+		helperWithCleanup(t)
+	})
+}
+
+func helperWithCleanup(t testing.TB) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		t.Helper()
+		t.Log("cleanup func log")
+	})
+}

--- a/testdata/cmp_test_results.json
+++ b/testdata/cmp_test_results.json
@@ -135,6 +135,11 @@
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_NestedCleanup/mix_nesting_and_skips","Output":"    --- SKIP: TestCmp_NestedCleanup/mix_nesting_and_skips (0.01s)\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"skip","Package":"github.com/prashantv/faket","Test":"TestCmp_NestedCleanup/mix_nesting_and_skips","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"pass","Package":"github.com/prashantv/faket","Test":"TestCmp_NestedCleanup","Elapsed":0}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"run","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupHelper"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupHelper","Output":"=== RUN   TestCmp_CleanupHelper\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupHelper","Output":"    integration_test.go:223: cleanup func log\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupHelper","Output":"--- PASS: TestCmp_CleanupHelper (0.01s)\n"}
+{"Time":"2022-06-11T00:00:00.0Z","Action":"pass","Package":"github.com/prashantv/faket","Test":"TestCmp_CleanupHelper","Elapsed":0}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"FAIL\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"exit status 1\n"}
 {"Time":"2022-06-11T00:00:00.0Z","Action":"output","Package":"github.com/prashantv/faket","Output":"FAIL\tgithub.com/prashantv/faket\t0.01s\n"}


### PR DESCRIPTION
If every function in `t.Cleanup` uses `t.Helper()` and logs, then the caller information skips to the caller of `t.Cleanup`. Track the caller of `Cleanup` and use that instead of reporting faketb as caller.