### PR TITLE
Refactor Logs APIs and implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-## TODO
-
-## Caller information
-
- * Provide ability to get structured information for logs which include caller, function, etc.
-   * Clean up the API around gettling logs (testing log output format, list, string, etc).

--- a/example_test.go
+++ b/example_test.go
@@ -28,11 +28,11 @@ func ExampleRunTest_failure() {
 	})
 
 	fmt.Println("Failed:", res.Failed())
-	fmt.Println("Logs:", res.Logs())
+	fmt.Println("Logs:", res.Logs().String())
 
 	// Output:
 	// Failed: true
-	// Logs: failed to find "helper" in remaining string " foo"
+	// Logs: example_test.go:16: failed to find "helper" in remaining string " foo"
 }
 
 func TestStrContainsInOrder(t *testing.T) {

--- a/exp/retryt/retryt_test.go
+++ b/exp/retryt/retryt_test.go
@@ -99,11 +99,13 @@ func TestN(t *testing.T) {
 			})
 			want.Equal(t, "Skipped", tr.Skipped(), tt.wantSkipped)
 			want.Equal(t, "Failed", tr.Failed(), tt.wantFailed)
+
+			gotLogs := tr.Logs().String()
 			for _, log := range tt.containsLogs {
-				want.Contains(t, "logs", tr.Logs(), log)
+				want.Contains(t, "logs", gotLogs, log)
 			}
 			for _, log := range tt.notContainsLogs {
-				want.NotContains(t, "logs", tr.Logs(), log)
+				want.NotContains(t, "logs", gotLogs, log)
 			}
 			want.Equal(t, "run count", count, tt.wantCount)
 		})
@@ -120,6 +122,8 @@ func TestRun_Defaults(t *testing.T) {
 	})
 	want.Equal(t, "Failed", tr.Failed(), true)
 	want.Equal(t, "run count", count, 10)
-	want.Contains(t, "logs", tr.Logs(), "fail")
-	want.NotContains(t, "logs", tr.Logs(), "retryt") // no logs by default
+
+	gotLogs := tr.Logs().String()
+	want.Contains(t, "logs", gotLogs, "fail")
+	want.NotContains(t, "logs", gotLogs, "retryt attempt") // no logs by default
 }

--- a/faket_test.go
+++ b/faket_test.go
@@ -13,5 +13,5 @@ func TestFakeT_Success(t *testing.T) {
 	want.Equal(t, "Failed", res.Failed(), false)
 	want.Equal(t, "Skipped", res.Skipped(), false)
 
-	want.Equal(t, "Logs", res.Logs(), "this is log 1")
+	want.DeepEqual(t, "Logs", res.Logs().Messages(), []string{"this is log 1"})
 }

--- a/internal/cmptest/cmptest.go
+++ b/internal/cmptest/cmptest.go
@@ -80,7 +80,7 @@ func CompareOpts(t *testing.T, opts Opts, f func(t testing.TB)) {
 
 	res := faket.RunTest(f)
 
-	var wantOutput []string
+	var wantOutput strings.Builder
 	realTestEvents := testEvents[t.Name()]
 	var resultEvent bool
 	for _, ev := range realTestEvents {
@@ -112,14 +112,13 @@ func CompareOpts(t *testing.T, opts Opts, f func(t testing.TB)) {
 				continue
 			}
 
-			trimmed = strings.TrimSuffix(trimmed, "\n")
-			wantOutput = append(wantOutput, trimmed)
+			wantOutput.WriteString(trimmed)
 		default:
 			t.Fatal("unknown action", ev.Action)
 		}
 	}
 
 	want.Equal(t, "result event", resultEvent, true)
-	want.DeepEqual(t, "log output", res.LogsWithCaller(), wantOutput)
+	want.Equal(t, "log output", res.Logs().String(), wantOutput.String())
 	want.Equal(t, "panicked", res.Panicked(), opts.WantPanic)
 }

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,0 +1,24 @@
+// Package sliceutil slice utilities that extend the stdlib slices package.
+package sliceutil
+
+// Map maps every element in `xs to a new slice using `fn`.
+func Map[X, Y any](xs []X, fn func(X) Y) []Y {
+	if xs == nil {
+		return nil
+	}
+
+	ys := make([]Y, len(xs))
+	for i := range xs {
+		ys[i] = fn(xs[i])
+	}
+	return ys
+}
+
+// ToSet converts a slice to a map with the elements as keys.
+func ToSet[X comparable](xs []X) map[X]struct{} {
+	set := make(map[X]struct{})
+	for _, x := range xs {
+		set[x] = struct{}{}
+	}
+	return set
+}

--- a/internal/sliceutil/sliceutil_test.go
+++ b/internal/sliceutil/sliceutil_test.go
@@ -1,0 +1,97 @@
+package sliceutil_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/prashantv/faket/internal/sliceutil"
+	"github.com/prashantv/faket/internal/want"
+)
+
+func TestMap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int
+		fn   func(int) string
+		want []string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty",
+			in:   []int{},
+			want: []string{},
+		},
+		{
+			name: "single element",
+			in:   []int{1},
+			want: []string{"1"},
+		},
+		{
+			name: "multiple elements",
+			in:   []int{1, 4, 7},
+			want: []string{"1", "4", "7"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sliceutil.Map(tt.in, strconv.Itoa)
+			want.DeepEqual(t, "Map", got, tt.want)
+		})
+	}
+}
+
+func TestToSet(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int
+		want map[int]struct{}
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: map[int]struct{}{},
+		},
+		{
+			name: "empty",
+			in:   []int{},
+			want: map[int]struct{}{},
+		},
+		{
+			name: "single element",
+			in:   []int{1},
+			want: map[int]struct{}{
+				1: {},
+			},
+		},
+		{
+			name: "unique",
+			in:   []int{1, 4, 7},
+			want: map[int]struct{}{
+				1: {},
+				4: {},
+				7: {},
+			},
+		},
+		{
+			name: "duplicates",
+			in:   []int{1, 4, 1, 7, 4},
+			want: map[int]struct{}{
+				1: {},
+				4: {},
+				7: {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sliceutil.ToSet(tt.in)
+			want.DeepEqual(t, "ToSet", got, tt.want)
+		})
+	}
+}

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -23,7 +23,7 @@ func (tr TestResult) MustFail(t testing.TB, wantLog string) {
 		t.Fatal("test passed, but expected to fail")
 	}
 
-	if !strings.Contains(tr.Logs(), wantLog) {
+	if !strings.Contains(tr.Logs().String(), wantLog) {
 		t.Fatalf("test expected to fail, missing expected log %q. logs:\n%v", wantLog, tr.Logs())
 	}
 }


### PR DESCRIPTION
`TestResult.Logs()` now returns a list of structured entries for logs.

Most callers will likely rely on `Logs.String()` to get a concatenated string
of all logs, in a format similar to `go test`. However, tests can also get a
list of messages, or work with the `Log` entry directly.

The log entry includes the message, caller information, and the `testing.TB`
function that was used to log. In the future, we can include caller PCs if 
there's use-cases, but PCs are not exposed due to the complexity of
merging caller PCs across the log caller, and possibly a cleanup caller.