### PR TITLE
Fix panics setting TestResult asynchronously

### DIFF
--- a/fake_tb.go
+++ b/fake_tb.go
@@ -55,8 +55,9 @@ func RunTest(testFn func(t testing.TB)) TestResult {
 	tb := newFakeTB()
 
 	go func() {
+		defer close(tb.completed)
 		defer tb.checkPanic()
-		defer tb.postTest()
+		defer tb.runCleanups()
 
 		testFn(tb)
 	}()
@@ -100,12 +101,6 @@ func (tb *fakeTB) checkPanic() {
 		tb.recoverCallers = getCallers(skipSelf)
 		tb.logfLocked(tb.recoverCallers, "panic: %v", r)
 	}
-}
-
-func (tb *fakeTB) postTest() {
-	defer close(tb.completed)
-
-	tb.runCleanups()
 }
 
 func (tb *fakeTB) runCleanups() {

--- a/faket_test.go
+++ b/faket_test.go
@@ -3,6 +3,7 @@ package faket
 import (
 	"testing"
 
+	"github.com/prashantv/faket/internal/syncutil"
 	"github.com/prashantv/faket/internal/want"
 )
 
@@ -41,3 +42,15 @@ func TestFakeT_Helpers(t *testing.T) {
 func testHelper1(t testing.TB) { t.Helper() }
 func testHelper2(t testing.TB) {}
 func testHelper3(t testing.TB) { t.Helper() }
+
+func TestFakeT_PanicRace(t *testing.T) {
+	syncutil.RunN(100, func(int) {
+		for i := 0; i < 100; i++ {
+			res := RunTest(func(t testing.TB) {
+				panic("panicked")
+			})
+			want.Equal(t, "Failed", res.Failed(), true)
+			want.Equal(t, "Panicked", res.Panicked(), true)
+		}
+	})
+}

--- a/internal/syncutil/syncutil.go
+++ b/internal/syncutil/syncutil.go
@@ -1,0 +1,19 @@
+// Package syncutil has helpers for running concurrent code.
+package syncutil
+
+import "sync"
+
+// RunN runs n items in parallel, with no concurrency limiting.
+func RunN(n int, fn func(i int)) {
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			fn(i)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/syncutil/syncutil_test.go
+++ b/internal/syncutil/syncutil_test.go
@@ -1,0 +1,21 @@
+package syncutil
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/prashantv/faket/internal/want"
+)
+
+func TestRunN(t *testing.T) {
+	const n = 10
+	var counter atomic.Int32
+	done := make(chan struct{})
+	RunN(n, func(i int) {
+		if counter.Add(1) == n {
+			close(done)
+		}
+		<-done
+	})
+	want.Equal(t, "counter", counter.Load(), 10)
+}


### PR DESCRIPTION
Panic handling is deferred before the defer that marks tests complete. This could lead to a test being marked complete, returning a result but then mutating that result after returning.

This happened infrequently but could lead to a flaky result where a panicked test isn't marked as `Failed()`. Added test runs many iterations so we are more likely to trigger a failure on flakes.