### PR TITLE
Update mise-action to v2.2.3 with cache key fix (#40)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,29 @@
+version: "2"
 linters:
   # Manually specify linters so we're not affected to changing defaults.
-  disable-all: true
+  default: none
   enable:
-    # golangci-lint defaults:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
+    - nolintlint
+    - revive
     - staticcheck
     - unused
-
-    # Our own extras:
+  settings:
+    govet:
+      # These govet checks are disabled by default, but they're useful.
+      enable:
+        - niliness
+        - stringintcov
+        - structtag
+  exclusions:
+    rules:
+      # Don't warn on unused parameters.
+      # # Parameter names are useful; replacing them with '_' is undesirable.
+      - linters: [revive]
+        text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+formatters:
+  enable:
     - gofumpt
     - goimports
-    - nolintlint # lints nolint directives
-    - revive
-
-linters-settings:
-  govet:
-    # These govet checks are disabled by default, but they're useful.
-    enable:
-      - niliness
-      - stringintcov
-      - structtag
-
-issues:
-  # disable default excludes, such as doc-comments for exported methods.
-  exclude-use-default: false
-
-  exclude-rules:
-    # Don't warn on unused parameters.
-    # Parameter names are useful; replacing them with '_' is undesirable.
-    - linters: [revive]
-      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.24"
-golangci-lint = "v1.63.4"
+golangci-lint = "v2.1.6"
 
 [tasks.build]
 description = "Build Go packages"


### PR DESCRIPTION
Picks up fix in https://github.com/jdx/mise-action/pull/196

We no longer need to set MISE_ENV in the cache key explicitly.